### PR TITLE
Minor fixes for cluster creation (Add helm repo & fix gcloud key export)

### DIFF
--- a/2-network-policies/apply.sh
+++ b/2-network-policies/apply.sh
@@ -42,6 +42,7 @@ function main() {
     writeEtcHosts "${externalIp}" "$(findIngressHostname "prometheus-server" "monitoring")"
 
     # Make sure mongodb is applied first, otherwise adminmongo seems not to show predefined DB
+    helm repo add bitnami https://charts.bitnami.com/bitnami
     helm upgrade --install mongo --namespace=production --version 9.2.4 \
         --values ${ABSOLUTE_BASEDIR}/mongodb/values.yaml \
          bitnami/mongodb

--- a/Readme.md
+++ b/Readme.md
@@ -118,7 +118,7 @@ gcloud projects add-iam-policy-binding ${PROJECT} \
 
 # Export credentials
 gcloud iam service-accounts keys create \
-  --iam-account serviceAccount:${SA}@${PROJECT}.iam.gserviceaccount.com terraform/account.json
+  --iam-account ${SA}@${PROJECT}.iam.gserviceaccount.com terraform/account.json
 ``` 
 * Have terraform installed (should work with 0.12 and 0.13)
 * Call `./create Cluster.sh`


### PR DESCRIPTION
Thanks for providing detailed examples for the K8s security tools!

I used this repo to test my changes concerning https://github.com/inovex/illuminatio/issues/131.

While  provisioning the examples of this repo I have encountered two issues:

- The export of the keys via gcloud cli did not work properly for me. After doing some investigation and checking the [docs](https://cloud.google.com/sdk/gcloud/reference/iam/service-accounts/keys/create) I got it working by removing the `serviceAccount:` prefix.

My local gcloud cli version:
```
Installation Root: [/usr/lib/google-cloud-sdk]
Installed Components:
  core: [2021.01.08]
  beta: [2021.01.08]
  gsutil: [4.57]
  bq: [2.0.64]
  alpha: [2021.01.08]
``` 

- The `apply.sh` script for the network policies failed, because helm was not able to determine the mongodb chart, so I have added the repo accordingly.